### PR TITLE
Bump the version to 1.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.zenuml</groupId>
     <artifactId>confluence-addon</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <organization>
         <name>P and D Vision</name>
         <url>https://www.zenuml.com/</url>


### PR DESCRIPTION
Bump up the release version. 1.0.5 has been used and versions cannot be reused.